### PR TITLE
Bump the pip group across 1 directory with 2 updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@ aiofiles
 apscheduler
 bard
 pornhub-api==0.2.0
-aiohttp==3.9.3
+aiohttp==3.9.4
 asyncio==3.4.3
 beautifulsoup4
 blackpink
 deepai
 pytube
-dnspython==2.3.0
+dnspython==2.6.1
 ffmpeg-python
 gitpython
 hachoir


### PR DESCRIPTION
Bumps the pip group with 2 updates in the / directory: [aiohttp](https://github.com/aio-libs/aiohttp) and [dnspython](https://github.com/rthalley/dnspython).


Updates `aiohttp` from 3.9.3 to 3.9.4
- [Release notes](https://github.com/aio-libs/aiohttp/releases)
- [Changelog](https://github.com/aio-libs/aiohttp/blob/master/CHANGES.rst)
- [Commits](https://github.com/aio-libs/aiohttp/compare/v3.9.3...v3.9.4)

Updates `dnspython` from 2.3.0 to 2.6.1
- [Release notes](https://github.com/rthalley/dnspython/releases)
- [Changelog](https://github.com/rthalley/dnspython/blob/main/doc/whatsnew.rst)
- [Commits](https://github.com/rthalley/dnspython/compare/v2.3.0...v2.6.1)

---
updated-dependencies:
- dependency-name: aiohttp dependency-type: direct:production dependency-group: pip
- dependency-name: dnspython dependency-type: direct:production dependency-group: pip ...